### PR TITLE
REJECT now uses REQUEST_CHANGES review instead of closing the PR

### DIFF
--- a/.github/workflows/auto-pr-reviewer.yaml
+++ b/.github/workflows/auto-pr-reviewer.yaml
@@ -71,15 +71,11 @@ jobs:
                          : 'REQUEST_REVIEW';
 
             if (decision === 'REJECT') {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: '❌ **PR rechazada automáticamente.** Los cambios presentan problemas que requieren corrección antes de continuar.'
-              });
-              await github.rest.pulls.update({
+              await github.rest.pulls.createReview({
                 ...context.repo,
                 pull_number: context.issue.number,
-                state: 'closed'
+                event: 'REQUEST_CHANGES',
+                body: '❌ **Se requieren cambios.** Los problemas detectados deben corregirse antes de continuar. Corrige y haz push para re-evaluar automáticamente.'
               });
             } else if (decision === 'APPROVE') {
               const titleMatch = lastComment.match(/## Merge Title: (.+)/);


### PR DESCRIPTION
## Cambio

Cuando el action decide REJECT, ahora crea una review de tipo `REQUEST_CHANGES` en lugar de cerrar la PR. Esto permite que el autor corrija los problemas, haga push, y el workflow se re-evalúe automáticamente.

**Antes**: cerraba la PR → el autor no podía re-abrirla sin intervención manual.

**Después**: solicita cambios formalmente → el autor corrige, pushea, y el action re-evalúa.

## Archivo modificado
- `.github/workflows/auto-pr-reviewer.yaml`