### PR TITLE
Fix: filtrar autor de la PR de la lista de revisores

### DIFF
--- a/.github/workflows/auto-pr-reviewer.yaml
+++ b/.github/workflows/auto-pr-reviewer.yaml
@@ -57,6 +57,14 @@ jobs:
         with:
           github-token: ${{ steps.bot-token.outputs.token }}
           script: |
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number
+            });
+
+            const allReviewers = ['alraro', 'fernan92005', 'alejandraortiz05', 'Chewi9', 'alexcalvo0101'];
+            const reviewers = allReviewers.filter(r => r !== pr.user.login);
+
             const { data: comments } = await github.rest.issues.listComments({
               ...context.repo,
               issue_number: context.issue.number,
@@ -98,7 +106,7 @@ jobs:
                 await github.rest.pulls.requestReviewers({
                   ...context.repo,
                   pull_number: context.issue.number,
-                  reviewers: ['alraro', 'fernan92005', 'alejandraortiz05', 'Chewi9', 'alexcalvo0101']
+                  reviewers
                 });
               }
             } else {
@@ -114,6 +122,6 @@ jobs:
               await github.rest.pulls.requestReviewers({
                 ...context.repo,
                 pull_number: context.issue.number,
-                reviewers: ['alraro', 'fernan92005', 'alejandraortiz05', 'Chewi9', 'alexcalvo0101']
+                reviewers
               });
             }


### PR DESCRIPTION
## Cambio

El workflow fallaba al intentar asignar como revisor al propio autor de la PR con el error `Review cannot be requested from pull request author`.

**Solución**: obtener el autor de la PR con `pulls.get()` y filtrarlo de la lista de revisores antes de asignar.

Si la PR es de `fernan92005`, se asigna a los otros 4. Si es de `alraro`, se asigna a los otros 4. Sin errores.

**Archivo**: `.github/workflows/auto-pr-reviewer.yaml`