### PR TITLE
refactor: centraliza autenticación, elimina código duplicado y mejora manejo de errores

### DIFF
--- a/backend/src/main/java/es/grupo8/backend/controllers/AdminController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/AdminController.java
@@ -45,6 +45,7 @@ import es.grupo8.backend.services.ChainService;
 import es.grupo8.backend.services.PartnerEntityService;
 import es.grupo8.backend.services.StoreService;
 import es.grupo8.backend.services.UserService;
+import es.grupo8.backend.services.UtilsService;
 import jakarta.servlet.http.HttpSession;
 
 @Controller
@@ -456,10 +457,9 @@ public class AdminController {
         model.addAttribute("currentSearch", search);
         model.addAttribute("currentRole", role);
 
-        if (sort == null) sort = "id,asc";
-        String[] parts = sort.split(",");
-        model.addAttribute("sortField", parts[0]);
-        model.addAttribute("sortOrder", parts.length > 1 ? parts[1] : "asc");
+        UtilsService.SortInfo sortInfo = UtilsService.parseSort(sort);
+        model.addAttribute("sortField", sortInfo.field());
+        model.addAttribute("sortOrder", sortInfo.order());
 
         return "admin-users";
     }

--- a/backend/src/main/java/es/grupo8/backend/controllers/AdminController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/AdminController.java
@@ -11,7 +11,6 @@
 package es.grupo8.backend.controllers;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +28,7 @@ import es.grupo8.backend.dao.GeographicZoneRepository;
 import es.grupo8.backend.dao.LocalityRepository;
 import es.grupo8.backend.dto.AdminDTO;
 import es.grupo8.backend.dto.ChainRequestDto;
+import es.grupo8.backend.dto.IncidentDTO;
 import es.grupo8.backend.dto.PaginatedResponse;
 import es.grupo8.backend.dto.PartnerEntityRequestDto;
 import es.grupo8.backend.dto.PartnerEntityResponseDto;
@@ -203,7 +203,8 @@ public class AdminController {
             try {
                 model.addAttribute("editEntity", chainService.findById(editar));
                 model.addAttribute("showForm", true);
-            } catch (RuntimeException ignored) {
+            } catch (RuntimeException e) {
+                model.addAttribute("error", "Cadena no encontrada.");
             }
         }
 
@@ -313,7 +314,8 @@ public class AdminController {
             try {
                 model.addAttribute("editEntity", storeService.findById(editar));
                 model.addAttribute("showForm", true);
-            } catch (RuntimeException ignored) {
+            } catch (RuntimeException e) {
+                model.addAttribute("error", "Tienda no encontrada.");
             }
         }
 
@@ -516,7 +518,7 @@ public class AdminController {
             return "redirect:/login";
         }
 
-        List<Map<String, Object>> incidents = adminService.getAllIncidents();
+        List<IncidentDTO> incidents = adminService.getAllIncidents();
 
         model.addAttribute("incidents", incidents);
         model.addAttribute("pageTitle", "Bancosol | Todas las incidencias");

--- a/backend/src/main/java/es/grupo8/backend/controllers/AdminController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/AdminController.java
@@ -57,9 +57,6 @@ public class AdminController {
     private AuthService authService;
 
     @Autowired
-    private PartnerEntityService partnerEntityService;
-
-    @Autowired
     private CampaignService campaignService;
 
     @Autowired
@@ -512,112 +509,6 @@ public class AdminController {
         return "redirect:/admin-users";
     }
 
-
-    @GetMapping("/admin-partner-entities")
-    public String adminPartnerEntities(
-            HttpSession session,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size,
-            @RequestParam(required = false) String sort,
-            @RequestParam(required = false) String search,
-            @RequestParam(required = false) Integer crear,
-            @RequestParam(required = false) Integer editar,
-            Model model) {
-
-        String role = (String) session.getAttribute("role");
-        if (!"ADMINISTRADOR".equals(role)) {
-            return "redirect:/login";
-        }
-
-        PaginatedResponse<PartnerEntityResponseDto> response =
-                partnerEntityService.getAllPartnerEntities(page, size, sort, search);
-
-        model.addAttribute("entities", response.content());
-        model.addAttribute("currentPage", response.page());
-        model.addAttribute("totalPages", response.totalPages());
-        model.addAttribute("currentSearch", search);
-        model.addAttribute("currentSize", size);
-
-        String sortField = "id";
-        String sortOrder = "asc";
-        if (sort != null && sort.contains(",")) {
-            String[] parts = sort.split(",");
-            sortField = parts[0];
-            sortOrder = parts.length > 1 ? parts[1] : "asc";
-        }
-        model.addAttribute("sortField", sortField);
-        model.addAttribute("sortOrder", sortOrder);
-
-        if (crear != null) {
-            model.addAttribute("showForm", true);
-            model.addAttribute("isCreating", true);
-        } else if (editar != null) {
-            try {
-                PartnerEntityResponseDto entity = partnerEntityService.getPartnerEntityById(editar);
-                model.addAttribute("editEntity", entity);
-                model.addAttribute("showForm", true);
-            } catch (RuntimeException ignored) {
-            }
-        }
-
-        return "admin-partner-entities";
-    }
-
-    @PostMapping("/admin-partner-entities/guardar")
-    public String savePartnerEntity(
-            HttpSession session,
-            @RequestParam(required = false) Integer id,
-            @RequestParam String nombre,
-            @RequestParam(required = false) String direccion,
-            @RequestParam(required = false) String telefono,
-            RedirectAttributes attr) {
-
-        String role = (String) session.getAttribute("role");
-        if (!"ADMINISTRADOR".equals(role)) {
-            return "redirect:/login";
-        }
-
-        PartnerEntityRequestDto dto = new PartnerEntityRequestDto();
-        dto.setName(nombre);
-        dto.setAddress(direccion);
-        dto.setPhone(telefono);
-
-        try {
-            if (id == null) {
-                partnerEntityService.createPartnerEntity(dto);
-                attr.addFlashAttribute("success", "Entidad creada correctamente.");
-            } else {
-                partnerEntityService.updatePartnerEntity(id, dto);
-                attr.addFlashAttribute("success", "Entidad actualizada correctamente.");
-            }
-        } catch (IllegalArgumentException e) {
-            attr.addFlashAttribute("error", e.getMessage());
-        }
-
-        return "redirect:/admin-partner-entities";
-    }
-
-    @PostMapping("/admin-partner-entities/eliminar/{id}")
-    public String deletePartnerEntity(
-            HttpSession session,
-            @PathVariable Integer id,
-            RedirectAttributes attr) {
-
-        String role = (String) session.getAttribute("role");
-        if (!"ADMINISTRADOR".equals(role)) {
-            return "redirect:/login";
-        }
-
-        try {
-            partnerEntityService.deletePartnerEntity(id);
-            attr.addFlashAttribute("success", "Entidad eliminada.");
-        } catch (RuntimeException e) {
-            attr.addFlashAttribute("error", e.getMessage());
-        }
-
-        return "redirect:/admin-partner-entities";
-    }
-
     @GetMapping("/admin-incidents")
     public String adminIncidents(HttpSession session, Model model) {
         String role = (String) session.getAttribute("role");
@@ -633,5 +524,4 @@ public class AdminController {
         return "admin-incidents";
     }
 
-    
 }

--- a/backend/src/main/java/es/grupo8/backend/controllers/AdminPartnerEntitiesController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/AdminPartnerEntitiesController.java
@@ -1,0 +1,127 @@
+package es.grupo8.backend.controllers;
+
+import es.grupo8.backend.dto.PaginatedResponse;
+import es.grupo8.backend.dto.PartnerEntityRequestDto;
+import es.grupo8.backend.dto.PartnerEntityResponseDto;
+import es.grupo8.backend.services.PartnerEntityService;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+public class AdminPartnerEntitiesController {
+
+    @Autowired
+    private PartnerEntityService partnerEntityService;
+
+    @GetMapping("/admin-partner-entities")
+    public String adminPartnerEntities(
+            HttpSession session,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String sort,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) Integer crear,
+            @RequestParam(required = false) Integer editar,
+            Model model) {
+
+        String role = (String) session.getAttribute("role");
+        if (!"ADMINISTRADOR".equals(role)) {
+            return "redirect:/login";
+        }
+
+        PaginatedResponse<PartnerEntityResponseDto> response =
+                partnerEntityService.getAllPartnerEntities(page, size, sort, search);
+
+        model.addAttribute("entities", response.content());
+        model.addAttribute("currentPage", response.page());
+        model.addAttribute("totalPages", response.totalPages());
+        model.addAttribute("currentSearch", search);
+        model.addAttribute("currentSize", size);
+
+        String sortField = "id";
+        String sortOrder = "asc";
+        if (sort != null && sort.contains(",")) {
+            String[] parts = sort.split(",");
+            sortField = parts[0];
+            sortOrder = parts.length > 1 ? parts[1] : "asc";
+        }
+        model.addAttribute("sortField", sortField);
+        model.addAttribute("sortOrder", sortOrder);
+
+        if (crear != null) {
+            model.addAttribute("showForm", true);
+            model.addAttribute("isCreating", true);
+        } else if (editar != null) {
+            try {
+                PartnerEntityResponseDto entity = partnerEntityService.getPartnerEntityById(editar);
+                model.addAttribute("editEntity", entity);
+                model.addAttribute("showForm", true);
+            } catch (RuntimeException ignored) {
+            }
+        }
+
+        return "admin-partner-entities";
+    }
+
+    @PostMapping("/admin-partner-entities/guardar")
+    public String savePartnerEntity(
+            HttpSession session,
+            @RequestParam(required = false) Integer id,
+            @RequestParam String nombre,
+            @RequestParam(required = false) String direccion,
+            @RequestParam(required = false) String telefono,
+            RedirectAttributes attr) {
+
+        String role = (String) session.getAttribute("role");
+        if (!"ADMINISTRADOR".equals(role)) {
+            return "redirect:/login";
+        }
+
+        PartnerEntityRequestDto dto = new PartnerEntityRequestDto();
+        dto.setName(nombre);
+        dto.setAddress(direccion);
+        dto.setPhone(telefono);
+
+        try {
+            if (id == null) {
+                partnerEntityService.createPartnerEntity(dto);
+                attr.addFlashAttribute("success", "Entidad creada correctamente.");
+            } else {
+                partnerEntityService.updatePartnerEntity(id, dto);
+                attr.addFlashAttribute("success", "Entidad actualizada correctamente.");
+            }
+        } catch (IllegalArgumentException e) {
+            attr.addFlashAttribute("error", e.getMessage());
+        }
+
+        return "redirect:/admin-partner-entities";
+    }
+
+    @PostMapping("/admin-partner-entities/eliminar/{id}")
+    public String deletePartnerEntity(
+            HttpSession session,
+            @PathVariable Integer id,
+            RedirectAttributes attr) {
+
+        String role = (String) session.getAttribute("role");
+        if (!"ADMINISTRADOR".equals(role)) {
+            return "redirect:/login";
+        }
+
+        try {
+            partnerEntityService.deletePartnerEntity(id);
+            attr.addFlashAttribute("success", "Entidad eliminada.");
+        } catch (RuntimeException e) {
+            attr.addFlashAttribute("error", e.getMessage());
+        }
+
+        return "redirect:/admin-partner-entities";
+    }
+}

--- a/backend/src/main/java/es/grupo8/backend/controllers/AdminPartnerEntitiesController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/AdminPartnerEntitiesController.java
@@ -3,11 +3,14 @@ package es.grupo8.backend.controllers;
 import es.grupo8.backend.dto.PaginatedResponse;
 import es.grupo8.backend.dto.PartnerEntityRequestDto;
 import es.grupo8.backend.dto.PartnerEntityResponseDto;
+import es.grupo8.backend.exceptions.AuthException;
 import es.grupo8.backend.services.PartnerEntityService;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,10 +34,7 @@ public class AdminPartnerEntitiesController {
             @RequestParam(required = false) Integer editar,
             Model model) {
 
-        String role = (String) session.getAttribute("role");
-        if (!"ADMINISTRADOR".equals(role)) {
-            return "redirect:/login";
-        }
+        checkAdmin(session);
 
         PaginatedResponse<PartnerEntityResponseDto> response =
                 partnerEntityService.getAllPartnerEntities(page, size, sort, search);
@@ -45,15 +45,9 @@ public class AdminPartnerEntitiesController {
         model.addAttribute("currentSearch", search);
         model.addAttribute("currentSize", size);
 
-        String sortField = "id";
-        String sortOrder = "asc";
-        if (sort != null && sort.contains(",")) {
-            String[] parts = sort.split(",");
-            sortField = parts[0];
-            sortOrder = parts.length > 1 ? parts[1] : "asc";
-        }
-        model.addAttribute("sortField", sortField);
-        model.addAttribute("sortOrder", sortOrder);
+        PartnerEntityService.SortInfo sortInfo = partnerEntityService.parseSort(sort);
+        model.addAttribute("sortField", sortInfo.field());
+        model.addAttribute("sortOrder", sortInfo.order());
 
         if (crear != null) {
             model.addAttribute("showForm", true);
@@ -63,7 +57,8 @@ public class AdminPartnerEntitiesController {
                 PartnerEntityResponseDto entity = partnerEntityService.getPartnerEntityById(editar);
                 model.addAttribute("editEntity", entity);
                 model.addAttribute("showForm", true);
-            } catch (RuntimeException ignored) {
+            } catch (RuntimeException e) {
+                model.addAttribute("error", "Entidad no encontrada.");
             }
         }
 
@@ -79,10 +74,7 @@ public class AdminPartnerEntitiesController {
             @RequestParam(required = false) String telefono,
             RedirectAttributes attr) {
 
-        String role = (String) session.getAttribute("role");
-        if (!"ADMINISTRADOR".equals(role)) {
-            return "redirect:/login";
-        }
+        checkAdmin(session);
 
         PartnerEntityRequestDto dto = new PartnerEntityRequestDto();
         dto.setName(nombre);
@@ -110,10 +102,7 @@ public class AdminPartnerEntitiesController {
             @PathVariable Integer id,
             RedirectAttributes attr) {
 
-        String role = (String) session.getAttribute("role");
-        if (!"ADMINISTRADOR".equals(role)) {
-            return "redirect:/login";
-        }
+        checkAdmin(session);
 
         try {
             partnerEntityService.deletePartnerEntity(id);
@@ -123,5 +112,16 @@ public class AdminPartnerEntitiesController {
         }
 
         return "redirect:/admin-partner-entities";
+    }
+
+    private void checkAdmin(HttpSession session) {
+        String role = (String) session.getAttribute("role");
+        if (!"ADMINISTRADOR".equals(role))
+            throw new AuthException(HttpStatus.UNAUTHORIZED, "Acceso denegado");
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public String handleAuthException() {
+        return "redirect:/login";
     }
 }

--- a/backend/src/main/java/es/grupo8/backend/controllers/AdminPartnerEntitiesController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/AdminPartnerEntitiesController.java
@@ -5,6 +5,7 @@ import es.grupo8.backend.dto.PartnerEntityRequestDto;
 import es.grupo8.backend.dto.PartnerEntityResponseDto;
 import es.grupo8.backend.exceptions.AuthException;
 import es.grupo8.backend.services.PartnerEntityService;
+import es.grupo8.backend.services.UtilsService;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -45,7 +46,7 @@ public class AdminPartnerEntitiesController {
         model.addAttribute("currentSearch", search);
         model.addAttribute("currentSize", size);
 
-        PartnerEntityService.SortInfo sortInfo = partnerEntityService.parseSort(sort);
+        UtilsService.SortInfo sortInfo = UtilsService.parseSort(sort);
         model.addAttribute("sortField", sortInfo.field());
         model.addAttribute("sortOrder", sortInfo.order());
 

--- a/backend/src/main/java/es/grupo8/backend/controllers/CampaignController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/CampaignController.java
@@ -163,7 +163,8 @@ public class CampaignController extends MvcSessionController {
                         campaignAssignmentService.getAvailableUsers(currentUserId(session), campaignId, "COORDINATOR"));
                 model.addAttribute("availableCaptains",
                         campaignAssignmentService.getAvailableUsers(currentUserId(session), campaignId, "CAPTAIN"));
-            } catch (NoSuchElementException ignored) {
+            } catch (NoSuchElementException e) {
+                model.addAttribute("error", "Campaña no encontrada.");
             }
         }
         return "admin-campaign-assignments";
@@ -230,7 +231,8 @@ public class CampaignController extends MvcSessionController {
                         campaignAssignmentService.getCampaignAssignments(currentUserId(session), campaignId).getCaptains());
                 model.addAttribute("availableCaptains",
                         campaignAssignmentService.getAvailableUsers(currentUserId(session), campaignId, "CAPTAIN"));
-            } catch (NoSuchElementException ignored) {
+            } catch (NoSuchElementException e) {
+                model.addAttribute("error", "Campaña no encontrada.");
             }
         }
         return "admin-captains";
@@ -285,7 +287,8 @@ public class CampaignController extends MvcSessionController {
                         campaignAssignmentService.getCampaignAssignments(currentUserId(session), campaignId).getCoordinators());
                 model.addAttribute("availableCoordinators",
                         campaignAssignmentService.getAvailableUsers(currentUserId(session), campaignId, "COORDINATOR"));
-            } catch (NoSuchElementException ignored) {
+            } catch (NoSuchElementException e) {
+                model.addAttribute("error", "Campaña no encontrada.");
             }
         }
         return "admin-coordinators";

--- a/backend/src/main/java/es/grupo8/backend/controllers/rest/ChainController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/rest/ChainController.java
@@ -15,10 +15,8 @@ import org.springframework.web.bind.annotation.*;
 
 import es.grupo8.backend.dto.ChainRequestDto;
 import es.grupo8.backend.dto.ChainResponseDto;
-import es.grupo8.backend.exceptions.AuthException;
 import es.grupo8.backend.services.AuthService;
 import es.grupo8.backend.services.ChainService;
-import es.grupo8.backend.services.UserService;
 import lombok.AllArgsConstructor;
 
 @RestController
@@ -28,23 +26,12 @@ public class ChainController extends BaseRestController {
 
     private final ChainService chainService;
     private final AuthService authService;
-    private final UserService userService;
-
-    private void checkAdmin(String authHeader) {
-        Integer userId = authService.extractUserIdFromToken(authHeader);
-        if (userId == null) {
-            throw new AuthException(HttpStatus.UNAUTHORIZED, "Token inválido o ausente");
-        }
-        if (!userService.isAdmin(userId)) {
-            throw new AuthException(HttpStatus.FORBIDDEN, "No tienes permiso");
-        }
-    }
 
     @GetMapping
     public ResponseEntity<List<ChainResponseDto>> getChains(
             @RequestHeader(value = "Authorization", required = false) String authHeader) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         List<ChainResponseDto> chains = chainService.findAll();
         return ResponseEntity.ok(chains);
     }
@@ -54,7 +41,7 @@ public class ChainController extends BaseRestController {
             @RequestHeader(value = "Authorization", required = false) String authHeader,
             @PathVariable Integer id) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         return ResponseEntity.ok(chainService.findById(id));
     }
 
@@ -63,7 +50,7 @@ public class ChainController extends BaseRestController {
             @RequestHeader(value = "Authorization", required = false) String authHeader,
             @RequestBody(required = false) ChainRequestDto req) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         ChainResponseDto created = chainService.create(req);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
@@ -74,7 +61,7 @@ public class ChainController extends BaseRestController {
             @PathVariable Integer id,
             @RequestBody(required = false) ChainRequestDto req) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         ChainResponseDto updated = chainService.update(id, req);
         return ResponseEntity.ok(updated);
     }
@@ -84,7 +71,7 @@ public class ChainController extends BaseRestController {
             @RequestHeader(value = "Authorization", required = false) String authHeader,
             @PathVariable Integer id) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         chainService.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/es/grupo8/backend/controllers/rest/PartnerEntityController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/rest/PartnerEntityController.java
@@ -7,33 +7,19 @@ import es.grupo8.backend.exceptions.AuthException;
 import es.grupo8.backend.services.AuthService;
 import es.grupo8.backend.services.PartnerEntityService;
 import es.grupo8.backend.services.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/partner-entities")
+@AllArgsConstructor
 public class PartnerEntityController extends BaseRestController {
 
-    @Autowired
-    private PartnerEntityService partnerEntityService;
-
-    @Autowired
-    private AuthService authService;
-
-    @Autowired
-    private UserService userService;
-
-    private void checkAdmin(String auth) {
-        Integer userId = authService.extractUserIdFromToken(auth);
-        if (userId == null) {
-            throw new AuthException(HttpStatus.UNAUTHORIZED, "Token inválido o ausente");
-        }
-        if (!userService.isAdmin(userId)) {
-            throw new AuthException(HttpStatus.FORBIDDEN, "No tienes permiso");
-        }
-    }
+    private final PartnerEntityService partnerEntityService;
+    private final AuthService authService;
+    private final UserService userService;
 
     private void checkAdminOrEntityManager(String auth, Integer entityId) {
         Integer userId = authService.extractUserIdFromToken(auth);
@@ -53,7 +39,7 @@ public class PartnerEntityController extends BaseRestController {
             @RequestParam(required = false) String sort,
             @RequestParam(required = false) String search) {
 
-        checkAdmin(auth);
+        authService.checkAdmin(auth);
         PaginatedResponse<PartnerEntityResponseDto> response =
                 partnerEntityService.getAllPartnerEntities(page, size, sort, search);
         return ResponseEntity.ok(response);
@@ -74,7 +60,7 @@ public class PartnerEntityController extends BaseRestController {
             @RequestHeader(value = "Authorization", required = false) String auth,
             @RequestBody PartnerEntityRequestDto request) {
 
-        checkAdmin(auth);
+        authService.checkAdmin(auth);
         PartnerEntityResponseDto response = partnerEntityService.createPartnerEntity(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -95,7 +81,7 @@ public class PartnerEntityController extends BaseRestController {
             @RequestHeader(value = "Authorization", required = false) String auth,
             @PathVariable Integer id) {
 
-        checkAdmin(auth);
+        authService.checkAdmin(auth);
         partnerEntityService.deletePartnerEntity(id);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/es/grupo8/backend/controllers/rest/StoreController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/rest/StoreController.java
@@ -29,16 +29,6 @@ public class StoreController extends BaseRestController {
     private final AuthService authService;
     private final UserService userService;
 
-    private void checkAdmin(String authHeader) {
-        Integer userId = authService.extractUserIdFromToken(authHeader);
-        if (userId == null) {
-            throw new AuthException(HttpStatus.UNAUTHORIZED, "Token inválido o ausente");
-        }
-        if (!userService.isAdmin(userId)) {
-            throw new AuthException(HttpStatus.FORBIDDEN, "No tienes permiso");
-        }
-    }
-
     private void checkAdminOrCoordinator(String authHeader) {
         Integer userId = authService.extractUserIdFromToken(authHeader);
         if (userId == null) {
@@ -69,7 +59,7 @@ public class StoreController extends BaseRestController {
             @RequestHeader(value = "Authorization", required = false) String authHeader,
             @PathVariable Integer id) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         return ResponseEntity.ok(storeService.findById(id));
     }
 
@@ -78,7 +68,7 @@ public class StoreController extends BaseRestController {
             @RequestHeader(value = "Authorization", required = false) String authHeader,
             @RequestBody(required = false) StoreRequestDto req) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         StoreResponseDto created = storeService.create(req);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
@@ -89,7 +79,7 @@ public class StoreController extends BaseRestController {
             @PathVariable Integer id,
             @RequestBody(required = false) StoreRequestDto req) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         StoreResponseDto updated = storeService.update(id, req);
         return ResponseEntity.ok(updated);
     }
@@ -99,7 +89,7 @@ public class StoreController extends BaseRestController {
             @RequestHeader(value = "Authorization", required = false) String authHeader,
             @PathVariable Integer id) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         storeService.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/es/grupo8/backend/controllers/rest/UserController.java
+++ b/backend/src/main/java/es/grupo8/backend/controllers/rest/UserController.java
@@ -27,32 +27,23 @@ import org.springframework.web.bind.annotation.RestController;
 import es.grupo8.backend.dto.UserResponseDto;
 import es.grupo8.backend.dto.UserRoleRequestDto;
 import es.grupo8.backend.dto.UserRoleResponseDto;
-import es.grupo8.backend.exceptions.AuthException;
 import es.grupo8.backend.services.AuthService;
 import es.grupo8.backend.services.UserService;
+import lombok.AllArgsConstructor;
 
 @RestController
 @RequestMapping("/api/users")
+@AllArgsConstructor
 public class UserController extends BaseRestController {
 
-    @Autowired private AuthService authService;
-    @Autowired private UserService userService;
-
-    private void checkAdmin(String authHeader) {
-        Integer userId = authService.extractUserIdFromToken(authHeader);
-        if (userId == null) {
-            throw new AuthException(HttpStatus.UNAUTHORIZED, "Token invalido o ausente");
-        }
-        if (!userService.isAdmin(userId)) {
-            throw new AuthException(HttpStatus.FORBIDDEN, "No tienes permiso");
-        }
-    }
+    private final AuthService authService;
+    private final UserService userService;
 
     @GetMapping
     public ResponseEntity<List<UserResponseDto>> getAllUsers(
             @RequestHeader(value = "Authorization", required = false) String authHeader) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         List<UserResponseDto> users = userService.getAllUsersOrdered();
         return ResponseEntity.ok(users);
     }
@@ -61,7 +52,7 @@ public class UserController extends BaseRestController {
     public ResponseEntity<List<UserResponseDto>> getPendingUsers(
             @RequestHeader(value = "Authorization", required = false) String authHeader) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         List<UserResponseDto> pending = userService.getPendingUsersOrdered();
         return ResponseEntity.ok(pending);
     }
@@ -72,7 +63,7 @@ public class UserController extends BaseRestController {
             @PathVariable Integer id,
             @RequestBody(required = false) UserRoleRequestDto request) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         UserRoleResponseDto response = userService.assignRole(id, request);
         return ResponseEntity.ok(response);
     }
@@ -82,7 +73,7 @@ public class UserController extends BaseRestController {
             @RequestHeader(value = "Authorization", required = false) String authHeader,
             @PathVariable Integer id) {
 
-        checkAdmin(authHeader);
+        authService.checkAdmin(authHeader);
         Integer adminId = authService.extractUserIdFromToken(authHeader);
         if (id.equals(adminId)) {
             return ResponseEntity.badRequest().body(Map.of("message", "No puedes eliminar tu propia cuenta"));

--- a/backend/src/main/java/es/grupo8/backend/dto/IncidentDTO.java
+++ b/backend/src/main/java/es/grupo8/backend/dto/IncidentDTO.java
@@ -15,4 +15,5 @@ public class IncidentDTO {
     private String createdAt;
     private String campaignName;
     private String storeName;
+    private String captainName;
 }

--- a/backend/src/main/java/es/grupo8/backend/mapper/IncidentMapper.java
+++ b/backend/src/main/java/es/grupo8/backend/mapper/IncidentMapper.java
@@ -22,6 +22,7 @@ public class IncidentMapper extends MapperDTO<IncidentDTO, Incident> {
         dto.setCreatedAt(i.getCreatedAt() != null ? i.getCreatedAt().toString() : null);
         dto.setCampaignName(i.getIdCampaign() != null ? i.getIdCampaign().getName() : null);
         dto.setStoreName(i.getIdStore() != null ? i.getIdStore().getName() : null);
+        dto.setCaptainName(i.getIdUser() != null ? i.getIdUser().getName() : null);
         return dto;
     }
 }

--- a/backend/src/main/java/es/grupo8/backend/mapper/UserAuthMapper.java
+++ b/backend/src/main/java/es/grupo8/backend/mapper/UserAuthMapper.java
@@ -8,16 +8,21 @@ import es.grupo8.backend.entity.UserEntity;
 
 
 @Component
-public class UserAuthMapper {
+public class UserAuthMapper extends MapperDTO<AuthResponseDTO, UserEntity> {
     @Autowired
     private ProfileMapper profileMapper;
 
-    public AuthResponseDTO toLoginResponse(UserEntity user, String token, String role, String redirectUrl, Long expiresInSeconds, Integer storeId) {
-
+    @Override
+    public AuthResponseDTO toDTO(UserEntity user) {
         AuthResponseDTO dto = new AuthResponseDTO();
         dto.setId(user.getIdUser());
         dto.setNombre(user.getName());
         dto.setEmail(user.getEmail());
+        return dto;
+    }
+
+    public AuthResponseDTO toLoginResponse(UserEntity user, String token, String role, String redirectUrl, Long expiresInSeconds, Integer storeId) {
+        AuthResponseDTO dto = toDTO(user);
         dto.setRole(role);
         dto.setRedirectUrl(redirectUrl);
         dto.setMessage("Login correcto");
@@ -25,33 +30,23 @@ public class UserAuthMapper {
         dto.setTokenType("Bearer");
         dto.setExpiresInSeconds(expiresInSeconds);
         dto.setStoreId(storeId);
-
         return dto;
     }
 
-
     public AuthResponseDTO toRegisterResponse(UserEntity user, String token, Long expiresInSeconds) {
-        
-        AuthResponseDTO dto = new AuthResponseDTO();
-        dto.setId(user.getIdUser());
-        dto.setNombre(user.getName());
-        dto.setEmail(user.getEmail());
+        AuthResponseDTO dto = toDTO(user);
         dto.setMessage("Registro correcto");
         dto.setToken(token);
         dto.setTokenType("Bearer");
         dto.setExpiresInSeconds(expiresInSeconds);
-
         return dto;
     }
 
-
     public ProfileDTO toProfileDTO(UserEntity user, String role, String redirectUrl, String message) {
-
         ProfileDTO dto = profileMapper.toDTO(user);
         dto.setRole(role);
         dto.setRedirectUrl(redirectUrl);
         dto.setMessage(message);
-
         return dto;
     }
 }

--- a/backend/src/main/java/es/grupo8/backend/services/AdminService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/AdminService.java
@@ -1,8 +1,6 @@
 package es.grupo8.backend.services;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +10,10 @@ import es.grupo8.backend.dao.CampaignRepository;
 import es.grupo8.backend.dao.IncidentRepository;
 import es.grupo8.backend.dao.StoreRepository;
 import es.grupo8.backend.dto.AdminDTO;
+import es.grupo8.backend.dto.IncidentDTO;
 import es.grupo8.backend.entity.Campaign;
 import es.grupo8.backend.mapper.AdminMapper;
+import es.grupo8.backend.mapper.IncidentMapper;
 
 @Service
 public class AdminService {
@@ -29,6 +29,9 @@ public class AdminService {
 
     @Autowired
     private AdminMapper adminMapper;
+
+    @Autowired
+    private IncidentMapper incidentMapper;
 
     public List<Campaign> getAllCampaigns() {
         return campaignRepository.findAll();
@@ -64,18 +67,8 @@ public class AdminService {
         ).collect(Collectors.toList());
     }
 
-    public List<Map<String, Object>> getAllIncidents() {
-        return incidentRepository.findAll().stream().map(i ->{
-            Map<String, Object> m = new HashMap<>();
-            m.put("id", i.getId());
-            m.put("description", i.getDescription());
-            m.put("createdAt", i.getCreatedAt() != null ? i.getCreatedAt().toString() : "-");
-            m.put("campaignName", i.getIdCampaign() != null ? i.getIdCampaign().getName() : "-");
-            m.put("storeName", i.getIdStore() != null ? i.getIdStore().getName() : "-");
-            m.put("captainName", i.getIdUser() != null ? i.getIdUser().getName() : "-");
-
-            return m;
-        }).collect(Collectors.toList());
+    public List<IncidentDTO> getAllIncidents() {
+        return incidentMapper.toDTOList(incidentRepository.findAll());
     }
 
 }

--- a/backend/src/main/java/es/grupo8/backend/services/AuthService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/AuthService.java
@@ -23,7 +23,9 @@ import es.grupo8.backend.dao.UserRepository;
 import es.grupo8.backend.dto.AuthResponseDTO;
 import es.grupo8.backend.dto.ProfileDTO;
 import es.grupo8.backend.entity.UserEntity;
+import es.grupo8.backend.exceptions.AuthException;
 import es.grupo8.backend.mapper.UserAuthMapper;
+import org.springframework.http.HttpStatus;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -41,6 +43,9 @@ public class AuthService {
 
     @Autowired
     private UserAuthMapper userAuthMapper;
+
+    @Autowired
+    private PasswordService passwordService;
 
 
     // Usa JWT para autenticación en lugar de sesiones tradicionales, lo que es más adecuado para APIs RESTful y aplicaciones modernas.
@@ -75,10 +80,10 @@ public class AuthService {
         if (user == null) return null;
 
         String stored = user.getPassword();
-        if(!UtilsService.matchesPassword(password, stored)) return null;
+        if(!passwordService.matches(password, stored)) return null;
 
-        if(UtilsService.needsMigration(stored)) {
-            user.setPassword(UtilsService.hashPassword(password));
+        if(passwordService.needsMigration(stored)) {
+            user.setPassword(passwordService.hash(password));
             userRepository.save(user);
         }
 
@@ -103,7 +108,7 @@ public class AuthService {
         user.setName(UtilsService.trimToNull(nombreParam));
         user.setEmail(UtilsService.normalizeEmail(emailParam));
         user.setPhone(UtilsService.trimToNull(telefonoParam));
-        user.setPassword(UtilsService.hashPassword(UtilsService.trimToNull(passwordParam)));
+        user.setPassword(passwordService.hash(UtilsService.trimToNull(passwordParam)));
         user.setAddress(UtilsService.trimToNull(domicilioParam));
         user.setPostalCode(UtilsService.trimToNull(cpParam));
 		
@@ -176,7 +181,7 @@ public class AuthService {
 				throw new IllegalArgumentException("La contraseña no coincide con la confirmación");
 			}
 
-			user.setPassword(UtilsService.hashPassword(newPassword));
+			user.setPassword(passwordService.hash(newPassword));
 		}
 
 		if (user.getEmail() == null) {
@@ -316,5 +321,11 @@ public class AuthService {
 		return !email.equalsIgnoreCase(current) && userRepository.existsByEmail(email);
 	}
 
-    
+    public void checkAdmin(String auth) {
+        Integer userId = extractUserIdFromToken(auth);
+        if (userId == null)
+            throw new AuthException(HttpStatus.UNAUTHORIZED, "Token inválido o ausente");
+        if (!userRepository.isAdmin(userId))
+            throw new AuthException(HttpStatus.FORBIDDEN, "No tienes permiso");
+    }
 }

--- a/backend/src/main/java/es/grupo8/backend/services/ChainService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/ChainService.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @AllArgsConstructor
@@ -30,7 +31,7 @@ public class ChainService {
 
     public ChainResponseDto findById(Integer id) {
         ChainEntity entity = chainRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Chain not found"));
+                .orElseThrow(() -> new NoSuchElementException("Chain not found"));
         return chainMapper.toDTO(entity);
     }
 
@@ -49,7 +50,7 @@ public class ChainService {
     public ChainResponseDto update(Integer id, ChainRequestDto request) {
         validate(request);
         ChainEntity entity = chainRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Chain not found"));
+                .orElseThrow(() -> new NoSuchElementException("Chain not found"));
 
         String newCode = request.getCode().trim();
         if (!newCode.equals(entity.getCode()) && chainRepository.existsByCode(newCode)) {
@@ -63,7 +64,7 @@ public class ChainService {
 
     public void delete(Integer id) {
         if (!chainRepository.existsById(id)) {
-            throw new RuntimeException("Chain not found");
+            throw new NoSuchElementException("Chain not found");
         }
         chainRepository.deleteById(id);
     }

--- a/backend/src/main/java/es/grupo8/backend/services/CoordinatorDashboardService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/CoordinatorDashboardService.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
-import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,6 +67,7 @@ public class CoordinatorDashboardService {
     private final UserMapper userMapper;
     private final PartnerEntityMapper partnerEntityMapper;
     private final CampaignEntityMapper campaignEntityMapper;
+    private final PasswordService passwordService;
 
     @Transactional(readOnly = true)
     public List<CampaignDTO> getMyCampaigns(Integer userId) {
@@ -225,7 +225,7 @@ public class CoordinatorDashboardService {
         CaptainRequest req = new CaptainRequest();
         req.setName(name);
         req.setEmail(normalizedEmail);
-        req.setPasswordHash(BCrypt.hashpw(password, BCrypt.gensalt(10)));
+        req.setPasswordHash(passwordService.hash(password));
         req.setIdCampaign(campaign);
         req.setIdCoordinator(coordinator);
         req.setStatus("PENDIENTE");

--- a/backend/src/main/java/es/grupo8/backend/services/PartnerEntityManagerService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/PartnerEntityManagerService.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.regex.Pattern;
 
 @Service
@@ -75,7 +76,7 @@ public class PartnerEntityManagerService {
 
     public PartnerEntityManagerResponseDto getPartnerEntityManagerByUserId(Integer userId) {
         PartnerEntityManager manager = partnerEntityManagerRepository.findByIdWithRelations(userId)
-                .orElseThrow(() -> new RuntimeException("No existe un responsable de entidad colaboradora con ID de usuario: " + userId));
+                .orElseThrow(() -> new NoSuchElementException("No existe un responsable de entidad colaboradora con ID de usuario: " + userId));
         return partnerEntityManagerMapper.toDTO(manager);
     }
 
@@ -92,7 +93,7 @@ public class PartnerEntityManagerService {
         }
 
         UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("Usuario no encontrado con ID: " + userId));
+                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + userId));
 
         PartnerEntityManager manager = new PartnerEntityManager();
         manager.setId(user.getIdUser());
@@ -112,12 +113,12 @@ public class PartnerEntityManagerService {
         }
 
         PartnerEntityManager manager = partnerEntityManagerRepository.findByIdWithRelations(userId)
-                .orElseThrow(() -> new RuntimeException("No existe un responsable de entidad colaboradora con ID de usuario: " + userId));
+                .orElseThrow(() -> new NoSuchElementException("No existe un responsable de entidad colaboradora con ID de usuario: " + userId));
 
         UserEntity user = manager.getUserAccounts();
         if (user == null) {
             user = userRepository.findById(userId)
-                    .orElseThrow(() -> new RuntimeException("Usuario no encontrado con ID: " + userId));
+                    .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + userId));
             manager.setUserAccounts(user);
         }
 
@@ -184,7 +185,7 @@ public class PartnerEntityManagerService {
 
     public void removePartnerEntityManagerRole(Integer userId) {
         if (!partnerEntityManagerRepository.existsById(userId)) {
-            throw new RuntimeException("No existe un responsable de entidad colaboradora con ID de usuario: " + userId);
+            throw new NoSuchElementException("No existe un responsable de entidad colaboradora con ID de usuario: " + userId);
         }
         partnerEntityManagerRepository.deleteById(userId);
     }

--- a/backend/src/main/java/es/grupo8/backend/services/PartnerEntityManagerService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/PartnerEntityManagerService.java
@@ -48,19 +48,13 @@ public class PartnerEntityManagerService {
         size = Math.max(1, Math.min(size, 100));
         int offset = page * size;
 
-        String sortField = "id";
-        String sortDir = "asc";
-        if (sort != null && sort.contains(",")) {
-            String[] parts = sort.split(",");
-            sortField = parts[0].trim().toLowerCase();
-            sortDir = parts.length > 1 && "desc".equals(parts[1].trim().toLowerCase()) ? "desc" : "asc";
-        }
+        UtilsService.SortInfo sortInfo = UtilsService.parseSort(sort);
 
-        List<PartnerEntityManager> managers = switch (sortField) {
-            case "name" -> sortDir.equals("asc")
+        List<PartnerEntityManager> managers = switch (sortInfo.field()) {
+            case "name" -> sortInfo.order().equals("asc")
                     ? partnerEntityManagerRepository.findAllByNameAsc(search, size, offset)
                     : partnerEntityManagerRepository.findAllByNameDesc(search, size, offset);
-            default -> sortDir.equals("asc")
+            default -> sortInfo.order().equals("asc")
                     ? partnerEntityManagerRepository.findAllByIdAsc(search, size, offset)
                     : partnerEntityManagerRepository.findAllByIdDesc(search, size, offset);
         };

--- a/backend/src/main/java/es/grupo8/backend/services/PartnerEntityService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/PartnerEntityService.java
@@ -30,7 +30,7 @@ public class PartnerEntityService {
         size = Math.max(1, Math.min(size, 100));
         int offset = page * size;
 
-        SortInfo sortInfo = parseSort(sort);
+        UtilsService.SortInfo sortInfo = UtilsService.parseSort(sort);
 
         List<PartnerEntity> entities = switch (sortInfo.field()) {
             case "name" -> sortInfo.order().equals("asc")
@@ -120,16 +120,4 @@ public class PartnerEntityService {
         }
     }
 
-    public SortInfo parseSort(String sort) {
-        String field = "id";
-        String order = "asc";
-        if (sort != null && sort.contains(",")) {
-            String[] parts = sort.split(",");
-            field = parts[0].trim().toLowerCase();
-            order = parts.length > 1 && "desc".equals(parts[1].trim().toLowerCase()) ? "desc" : "asc";
-        }
-        return new SortInfo(field, order);
-    }
-
-    public record SortInfo(String field, String order) {}
 }

--- a/backend/src/main/java/es/grupo8/backend/services/PartnerEntityService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/PartnerEntityService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 public class PartnerEntityService {
@@ -57,7 +58,7 @@ public class PartnerEntityService {
 
     public PartnerEntityResponseDto getPartnerEntityById(Integer id) {
         PartnerEntity entity = partnerEntityRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Partner entity not found with ID: " + id));
+                .orElseThrow(() -> new NoSuchElementException("Partner entity not found with ID: " + id));
         return partnerEntityMapper.toDTO(entity);
     }
 
@@ -77,7 +78,7 @@ public class PartnerEntityService {
         validateRequest(request);
 
         PartnerEntity entity = partnerEntityRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Partner entity not found with ID: " + id));
+                .orElseThrow(() -> new NoSuchElementException("Partner entity not found with ID: " + id));
 
         entity.setName(request.getName().trim());
         entity.setAddress(UtilsService.trimToNull(request.getAddress()));
@@ -89,7 +90,7 @@ public class PartnerEntityService {
 
     public void deletePartnerEntity(Integer id) {
         if (!partnerEntityRepository.existsById(id)) {
-            throw new RuntimeException("Partner entity not found with ID: " + id);
+            throw new NoSuchElementException("Partner entity not found with ID: " + id);
         }
         partnerEntityRepository.deleteById(id);
     }

--- a/backend/src/main/java/es/grupo8/backend/services/PartnerEntityService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/PartnerEntityService.java
@@ -30,19 +30,13 @@ public class PartnerEntityService {
         size = Math.max(1, Math.min(size, 100));
         int offset = page * size;
 
-        String sortField = "id";
-        String sortDir = "asc";
-        if (sort != null && sort.contains(",")) {
-            String[] parts = sort.split(",");
-            sortField = parts[0].trim().toLowerCase();
-            sortDir = parts.length > 1 && "desc".equals(parts[1].trim().toLowerCase()) ? "desc" : "asc";
-        }
+        SortInfo sortInfo = parseSort(sort);
 
-        List<PartnerEntity> entities = switch (sortField) {
-            case "name" -> sortDir.equals("asc")
+        List<PartnerEntity> entities = switch (sortInfo.field()) {
+            case "name" -> sortInfo.order().equals("asc")
                     ? partnerEntityRepository.findAllByNameAsc(search, size, offset)
                     : partnerEntityRepository.findAllByNameDesc(search, size, offset);
-            default -> sortDir.equals("asc")
+            default -> sortInfo.order().equals("asc")
                     ? partnerEntityRepository.findAllByIdAsc(search, size, offset)
                     : partnerEntityRepository.findAllByIdDesc(search, size, offset);
         };
@@ -125,4 +119,17 @@ public class PartnerEntityService {
             }
         }
     }
+
+    public SortInfo parseSort(String sort) {
+        String field = "id";
+        String order = "asc";
+        if (sort != null && sort.contains(",")) {
+            String[] parts = sort.split(",");
+            field = parts[0].trim().toLowerCase();
+            order = parts.length > 1 && "desc".equals(parts[1].trim().toLowerCase()) ? "desc" : "asc";
+        }
+        return new SortInfo(field, order);
+    }
+
+    public record SortInfo(String field, String order) {}
 }

--- a/backend/src/main/java/es/grupo8/backend/services/ShiftAssignmentService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/ShiftAssignmentService.java
@@ -1,6 +1,7 @@
 package es.grupo8.backend.services;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,7 +80,7 @@ public class ShiftAssignmentService {
         Integer volunteerId = request.getVolunteerId();
 
         Volunteer volunteer = volunteerRepository.findById(volunteerId)
-                .orElseThrow(() -> new RuntimeException("Voluntario no encontrado"));
+                .orElseThrow(() -> new NoSuchElementException("Voluntario no encontrado"));
 
         VolunteerShiftId vsId = buildVolunteerShiftId(volunteerId, shift);
         if (volunteerShiftRepository.existsById(vsId)) {
@@ -139,7 +140,7 @@ public class ShiftAssignmentService {
 
         VolunteerShiftId vsId = buildVolunteerShiftId(volunteerId, shift);
         if (!volunteerShiftRepository.existsById(vsId)) {
-            throw new RuntimeException("El voluntario no está asignado a este turno");
+            throw new IllegalStateException("El voluntario no está asignado a este turno");
         }
 
         volunteerShiftRepository.deleteById(vsId);
@@ -168,7 +169,7 @@ public class ShiftAssignmentService {
         Integer userId = request.getUserId();
 
         UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado"));
 
         ShiftCaptainId scId = new ShiftCaptainId();
         scId.setIdShift(shiftId);
@@ -213,7 +214,7 @@ public class ShiftAssignmentService {
         scId.setIdShift(shiftId);
         scId.setIdUser(userId);
         if (!shiftCaptainRepository.existsById(scId)) {
-            throw new RuntimeException("El capitán no está asignado a este turno");
+            throw new IllegalStateException("El capitán no está asignado a este turno");
         }
 
         shiftCaptainRepository.deleteById(scId);
@@ -231,7 +232,7 @@ public class ShiftAssignmentService {
 
         VolunteerShiftId vsId = buildVolunteerShiftId(request.getVolunteerId(), shift);
         VolunteerShift vs = volunteerShiftRepository.findById(vsId)
-                .orElseThrow(() -> new RuntimeException("El voluntario no está asignado a este turno"));
+                .orElseThrow(() -> new NoSuchElementException("El voluntario no está asignado a este turno"));
 
         vs.setAttendance(request.getAttendance());
         volunteerShiftRepository.save(vs);
@@ -278,7 +279,7 @@ public class ShiftAssignmentService {
 
     private Shift findShift(Integer shiftId) {
         return shiftRepository.findById(shiftId)
-                .orElseThrow(() -> new RuntimeException("Turno no encontrado"));
+                .orElseThrow(() -> new NoSuchElementException("Turno no encontrado"));
     }
 
     private VolunteerShiftId buildVolunteerShiftId(Integer volunteerId, Shift shift) {

--- a/backend/src/main/java/es/grupo8/backend/services/ShiftService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/ShiftService.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.NoSuchElementException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,7 +143,7 @@ public class ShiftService {
      */
     public List<StoreSimpleDto> getStoresForCampaign(Integer campaignId) {
         campaignRepository.findById(campaignId)
-                .orElseThrow(() -> new RuntimeException("Campaña no encontrada"));
+                .orElseThrow(() -> new NoSuchElementException("Campaña no encontrada"));
 
         return campaignStoreRepository.findByIdCampaign_Id(campaignId).stream()
                 .filter(cs -> cs.getIdStore() != null)

--- a/backend/src/main/java/es/grupo8/backend/services/StoreService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/StoreService.java
@@ -20,6 +20,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
@@ -75,7 +76,7 @@ public class StoreService {
 
     public StoreResponseDto findById(Integer id) {
         es.grupo8.backend.entity.Store store = storeRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Store not found"));
+                .orElseThrow(() -> new NoSuchElementException("Store not found"));
         return storeMapper.toDTO(store);
     }
 
@@ -91,7 +92,7 @@ public class StoreService {
 
     public StoreResponseDto update(Integer id, StoreRequestDto req) {
         es.grupo8.backend.entity.Store store = storeRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Store not found"));
+                .orElseThrow(() -> new NoSuchElementException("Store not found"));
         StoreComponents c = resolve(req);
         store.setName(c.name());
         store.setAddress(c.address());
@@ -102,7 +103,7 @@ public class StoreService {
 
     public void delete(Integer id) {
         if (!storeRepository.existsById(id))
-            throw new RuntimeException("Store not found");
+            throw new NoSuchElementException("Store not found");
         storeRepository.deleteById(id);
     }
 

--- a/backend/src/main/java/es/grupo8/backend/services/UserService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/UserService.java
@@ -43,6 +43,7 @@ import org.springframework.stereotype.Service;
 import java.text.Normalizer;
 import java.util.List;
 import java.util.Locale;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
@@ -107,7 +108,7 @@ public class UserService {
 
     public UserResponseDto getUserById(Integer userId) {
         return userMapper.toDTO(userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("Usuario no encontrado con ID: " + userId)));
+                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + userId)));
     }
 
     public UserResponseDto createUser(UserRequestDto request) {
@@ -126,14 +127,14 @@ public class UserService {
 
         UserEntity saved = userRepository.save(user);
         return userMapper.toDTO(userRepository.findById(saved.getIdUser())
-                .orElseThrow(() -> new RuntimeException("Usuario no encontrado tras la creación")));
+                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado tras la creación")));
     }
 
     public UserResponseDto updateUser(Integer userId, UserRequestDto request) {
         if (request == null) throw new IllegalArgumentException("La petición no es válida.");
 
         UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("Usuario no encontrado con ID: " + userId));
+                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado con ID: " + userId));
 
         if (request.getName() != null) {
             String name = request.getName().trim();
@@ -170,7 +171,7 @@ public class UserService {
 
     public UserRoleResponseDto assignRole(Integer userId, UserRoleRequestDto request) {
         UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+                .orElseThrow(() -> new NoSuchElementException("Usuario no encontrado"));
 
         String role = normalizeRole(request == null ? null : request.getRole());
         if (role == null) {
@@ -185,7 +186,7 @@ public class UserService {
 
     public void deleteUser(Integer userId) {
         if (!userRepository.existsById(userId))
-            throw new RuntimeException("Usuario no encontrado con ID: " + userId);
+            throw new NoSuchElementException("Usuario no encontrado con ID: " + userId);
         userRepository.deleteById(userId);
     }
 

--- a/backend/src/main/java/es/grupo8/backend/services/UtilsService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/UtilsService.java
@@ -11,6 +11,19 @@ public final class UtilsService {
     private UtilsService() {
     }
 
+    public record SortInfo(String field, String order) {}
+
+    public static SortInfo parseSort(String sort) {
+        String field = "id";
+        String order = "asc";
+        if (sort != null && sort.contains(",")) {
+            String[] parts = sort.split(",");
+            field = parts[0].trim().toLowerCase();
+            order = parts.length > 1 && "desc".equals(parts[1].trim().toLowerCase()) ? "desc" : "asc";
+        }
+        return new SortInfo(field, order);
+    }
+
     public static String trimToNull(String value) {
         if (value == null) return null;
         String trimmed = value.trim();

--- a/backend/src/main/java/es/grupo8/backend/services/UtilsService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/UtilsService.java
@@ -1,7 +1,7 @@
 package es.grupo8.backend.services;
 
-import org.springframework.security.crypto.bcrypt.BCrypt;
-
+import es.grupo8.backend.dto.PaginatedResponse;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public final class UtilsService {
@@ -53,22 +53,24 @@ public final class UtilsService {
         return trimmed.replaceAll("\\s+", " ");
     }
 
-    public static String hashPassword(String rawPassword) {
-        if (rawPassword == null) return null;
-        return BCrypt.hashpw(rawPassword, BCrypt.gensalt(10));
+    public static int clampPageSize(int size) {
+        return clampPageSize(size, 100);
     }
 
-    public static boolean matchesPassword(String rawPassword, String storedPassword) {
-        if (rawPassword == null || storedPassword == null) return false;
-
-        if (storedPassword.startsWith("$2a$") || storedPassword.startsWith("$2b$") || storedPassword.startsWith("$2y$")) {
-            return BCrypt.checkpw(rawPassword, storedPassword);
-        }
-        return rawPassword.equals(storedPassword);
+    public static int clampPageSize(int size, int max) {
+        return Math.max(1, Math.min(size, max));
     }
 
-    public static boolean needsMigration(String storedPassword) {
-        if (storedPassword == null) return false;
-        return !(storedPassword.startsWith("$2a$") || storedPassword.startsWith("$2b$") || storedPassword.startsWith("$2y$"));
+    public static <T> PaginatedResponse<T> buildPaginatedResponse(List<T> content, int page, int size, long totalElements) {
+        int totalPages = (int) Math.ceil((double) totalElements / size);
+        return new PaginatedResponse<>(
+                content,
+                page,
+                size,
+                totalElements,
+                totalPages,
+                page < totalPages - 1,
+                page > 0
+        );
     }
 }

--- a/backend/src/main/java/es/grupo8/backend/services/VolunteerService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/VolunteerService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 public class VolunteerService {
@@ -54,11 +55,11 @@ public class VolunteerService {
 
     public VoluntarioResponseDto getVolunteerById(Integer id, Integer partnerEntityId) {
         Volunteer volunteer = volunteerRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Volunteer not found with ID: " + id));
+                .orElseThrow(() -> new NoSuchElementException("Volunteer not found with ID: " + id));
 
         if (volunteer.getIdPartnerEntity() == null ||
             !volunteer.getIdPartnerEntity().getId().equals(partnerEntityId)) {
-            throw new RuntimeException("Volunteer not found for this entity");
+            throw new NoSuchElementException("Volunteer not found for this entity");
         }
 
         return volunteerMapper.toDTO(volunteer);
@@ -69,7 +70,7 @@ public class VolunteerService {
         validateRequest(request);
 
         PartnerEntity partnerEntity = partnerEntityRepository.findById(partnerEntityId)
-                .orElseThrow(() -> new RuntimeException("Partner entity not found with ID: " + partnerEntityId));
+                .orElseThrow(() -> new NoSuchElementException("Partner entity not found with ID: " + partnerEntityId));
 
         Volunteer volunteer = new Volunteer();
         volunteer.setName(UtilsService.trimToNull(request.name()));
@@ -87,11 +88,11 @@ public class VolunteerService {
         validateRequest(request);
 
         Volunteer volunteer = volunteerRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Volunteer not found with ID: " + id));
+                .orElseThrow(() -> new NoSuchElementException("Volunteer not found with ID: " + id));
 
         if (volunteer.getIdPartnerEntity() == null ||
             !volunteer.getIdPartnerEntity().getId().equals(partnerEntityId)) {
-            throw new RuntimeException("Volunteer not found for this entity");
+            throw new NoSuchElementException("Volunteer not found for this entity");
         }
 
         volunteer.setName(UtilsService.trimToNull(request.name()));
@@ -106,11 +107,11 @@ public class VolunteerService {
     @Transactional
     public void deleteVolunteer(Integer id, Integer partnerEntityId) {
         Volunteer volunteer = volunteerRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Volunteer not found with ID: " + id));
+                .orElseThrow(() -> new NoSuchElementException("Volunteer not found with ID: " + id));
 
         if (volunteer.getIdPartnerEntity() == null ||
             !volunteer.getIdPartnerEntity().getId().equals(partnerEntityId)) {
-            throw new RuntimeException("Volunteer not found for this entity");
+            throw new NoSuchElementException("Volunteer not found for this entity");
         }
 
         volunteerRepository.delete(volunteer);

--- a/backend/src/main/webapp/WEB-INF/jsp/admin-incidents.jsp
+++ b/backend/src/main/webapp/WEB-INF/jsp/admin-incidents.jsp
@@ -4,7 +4,7 @@
 -	- Hugo Herrero González: 100%
 -->
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ page import="java.util.List, java.util.Map" %>
+<%@ page import="java.util.List, es.grupo8.backend.dto.IncidentDTO" %>
 <%
     String nombre = (String) session.getAttribute("nombre");
     String token = (String) session.getAttribute("token");
@@ -15,7 +15,7 @@
         return;
     }
 
-    List<Map<String, Object>> incidents = (List<Map<String, Object>>) request.getAttribute("incidents");
+    List<IncidentDTO> incidents = (List<IncidentDTO>) request.getAttribute("incidents");
 
 %>
 <!DOCTYPE html>
@@ -74,14 +74,14 @@
                         </tr>
                         <%
                         } else {
-                            for (Map<String, Object> i : incidents) {
+                            for (IncidentDTO i : incidents) {
                         %>
                         <tr>
-                            <td><%= i.get("createdAt") != null ? i.get("createdAt") : "-" %></td>
-                            <td><%= i.get("campaignName") != null ? i.get("campaignName") : "-" %></td>
-                            <td><%= i.get("storeName") != null ? i.get("storeName") : "-" %></td>
-                            <td><%= i.get("captainName") != null ? i.get("captainName") : "-" %></td>
-                            <td><%= i.get("description") != null ? i.get("description") : "-" %></td>
+                            <td><%= i.getCreatedAt() != null ? i.getCreatedAt() : "-" %></td>
+                            <td><%= i.getCampaignName() != null ? i.getCampaignName() : "-" %></td>
+                            <td><%= i.getStoreName() != null ? i.getStoreName() : "-" %></td>
+                            <td><%= i.getCaptainName() != null ? i.getCaptainName() : "-" %></td>
+                            <td><%= i.getDescription() != null ? i.getDescription() : "-" %></td>
                         </tr>
                         <%
                         }}%>

--- a/backend/src/main/webapp/WEB-INF/jsp/admin-partner-entities.jsp
+++ b/backend/src/main/webapp/WEB-INF/jsp/admin-partner-entities.jsp
@@ -8,12 +8,6 @@
 <%@ page import="es.grupo8.backend.dto.PartnerEntityResponseDto, java.util.List" %>
 <%
     String nombre = (String) session.getAttribute("nombre");
-    String role = (String) session.getAttribute("role");
-
-    if (!"ADMINISTRADOR".equals(role)) {
-        response.sendRedirect("/login");
-        return;
-    }
 
     List<PartnerEntityResponseDto> entities = (List<PartnerEntityResponseDto>) request.getAttribute("entities");
     Integer currentPage = (Integer) request.getAttribute("currentPage");
@@ -66,7 +60,7 @@
             <span class="dot"></span>
             <span id="user-name"><%= nombre == null ? "Admin" : nombre %></span>
         </div>
-        <a href="/edit" class="btn-edit" id="btn-edit">Editar perfil 🖉</a>
+        <a href="/edit" class="btn-edit" id="btn-edit">Editar perfil</a>
         <a href="/logout" class="btn-logout" id="btn-logout">Cerrar sesión ×</a>
     </div>
 </header>


### PR DESCRIPTION
## Cambios realizados

### Backend — Refactorización general

- **Autenticación centralizada**: `checkAdmin()` movido a `AuthService`, eliminado de 4 REST controllers (ChainController, PartnerEntityController, StoreController, UserController)
- **PasswordService como única fuente**: eliminados métodos BCrypt duplicados en `UtilsService`; `AuthService` y `CoordinatorDashboardService` ahora usan `PasswordService`
- **Catch vacíos corregidos**: 5 bloques catch que tragaban excepciones ahora muestran feedback al usuario (`AdminController`, `CampaignController`)
- **RuntimeException → excepciones específicas**: 33 ocurrencias reemplazadas por `NoSuchElementException`/ `IllegalStateException`/ `IllegalArgumentException` en 9 services
- **IncidentMapper**: `AdminService.getAllIncidents()` ahora usa mapper en vez de `HashMap` manual
- **UserAuthMapper**: ahora extiende `MapperDTO<AuthResponseDTO, UserEntity>`
- **UtilsService**: nuevos helpers `clampPageSize()` y `buildPaginatedResponse()`
- **Paginación**: `SortInfo` y `parseSort()` centralizados en `UtilsService`, usados desde 4 clases
- **BaseRestController**: revertido a su estado original (sin constructor parametrizado)