### PR TITLE
Ordenar por nombre de campaña

### DIFF
--- a/backend/src/main/java/es/grupo8/backend/dao/IncidentRepository.java
+++ b/backend/src/main/java/es/grupo8/backend/dao/IncidentRepository.java
@@ -26,9 +26,9 @@ public interface IncidentRepository extends JpaRepository<Incident, Integer> {
     List<Incident> findByUserId(@Param("userId") Integer userId);
 
 
-    @Query("SELECT i FROM Incident i ORDER BY i.id ASC")
-    List<Incident> findAllOrderByIdAsc();
+    @Query("SELECT i FROM Incident i ORDER BY i.idCampaign.name ASC")
+    List<Incident> findAllOrderByCampaignNameAsc();
 
-    @Query("SELECT i FROM Incident i ORDER BY i.id DESC")
-    List<Incident> findAllOrderByIdDesc();
+    @Query("SELECT i FROM Incident i ORDER BY i.idCampaign.name DESC")
+    List<Incident> findAllOrderByCampaignNameDesc();
 }

--- a/backend/src/main/java/es/grupo8/backend/services/AdminService.java
+++ b/backend/src/main/java/es/grupo8/backend/services/AdminService.java
@@ -78,9 +78,9 @@ public class AdminService {
         List<Incident> incidents;
 
         if ("asc".equals(dir)){
-            incidents = incidentRepository.findAllOrderByIdAsc();
+            incidents = incidentRepository.findAllOrderByCampaignNameAsc();
         } else {
-            incidents = incidentRepository.findAllOrderByIdDesc();
+            incidents = incidentRepository.findAllOrderByCampaignNameDesc();
         }
         
         


### PR DESCRIPTION
This pull request updates how incidents are sorted and retrieved in the backend. Instead of sorting incidents by their ID, the system now sorts them by the name of their associated campaign. This change affects both the repository queries and the service logic that fetches incident data.

**Repository query updates:**

* Changed the `IncidentRepository` methods to sort incidents by `idCampaign.name` (the campaign name) in ascending and descending order, instead of sorting by incident ID.

**Service logic update:**

* Updated the `AdminService` to use the new repository methods, so that calls to get all incidents now return results ordered by campaign name rather than by incident ID.